### PR TITLE
Added assignments for $last0 and $last1 variables

### DIFF
--- a/IpDbGenerate.php
+++ b/IpDbGenerate.php
@@ -35,6 +35,9 @@ foreach ($keys as $k => $v) {
         print_r($v);
         die;
     }
+
+    $last0 = $i0;
+    $last1 = $i1;
     $ary[] = $v;
 }
 


### PR DESCRIPTION
I noticed that in the safety check loop the $last0 and $last1 variables are un-assigned.  Hence this simple patch.
