### PR TITLE
Update Ruby client to use native CSV parser

### DIFF
--- a/ipcat.rb
+++ b/ipcat.rb
@@ -1,4 +1,5 @@
 require "ipaddr"
+require "csv"
 
 module IPCat
 
@@ -9,7 +10,7 @@ module IPCat
       @ends = Array.new
       @urls = Array.new
       File.open(file, "r").readlines.map do |line|
-        add(*line.chomp.split(','))
+        add(*CSV.parse_line(line))
       end
     end
 


### PR DESCRIPTION
Just splitting the string on commas is not a proper CSV
parser and breaks now that the data contains commas.

Fixes #103 

The existing code was choking on lines like this:

```
64.5.32.0,64.5.63.255,"ThePlanet.com Internet Services, Inc.",http://theplanet.com
```

Ruby 2 added a [CSV parser in stdlib](http://ruby-doc.org/stdlib-2.0.0/libdoc/csv/rdoc/CSV.html), so let's use that. This probably means that Ruby 1.8 will no longer work, if anyone is still using that, but this bug would have kept them from being able to load data anyway.